### PR TITLE
feat(home-assistant): add quick_timer badge and Timers subview to main dashboard

### DIFF
--- a/home-assistant/config/dashboards/lovelace.yaml
+++ b/home-assistant/config/dashboards/lovelace.yaml
@@ -43,6 +43,14 @@ strategy:
       climate_count: false
       cover_count: false
       extra_badges:
+        - content_info: state
+          entity: sensor.quick_timer_monitor
+          icon: mdi:timer-outline
+          icon_color: amber
+          tap_action:
+            action: navigate
+            navigation_path: /lovelace/timers
+          type: entity
         - content_info: name
           entity: scene.bedtime
           icon_color: primary
@@ -60,6 +68,18 @@ strategy:
     domains:
       _:
         hide_config_entities: true
+    extra_views:
+      - cards:
+          - title: Active Timers
+            type: custom:quick-timer-overview-card
+          - default_delay: 30
+            default_unit: minutes
+            mode: full
+            type: custom:quick-timer-card
+        icon: mdi:timer-outline
+        path: timers
+        subview: true
+        title: Timers
     home_view:
       hidden:
         - areasTitle

--- a/home-assistant/config/registry/floors.yaml
+++ b/home-assistant/config/registry/floors.yaml
@@ -1,0 +1,9 @@
+first:
+  level: 1
+  name: First
+ground:
+  level: 0
+  name: Ground
+second:
+  level: 2
+  name: Second


### PR DESCRIPTION
## What

Adds [quick_timer](https://github.com/jozefnad/homeassistant-quick_timer) to the main mushroom-strategy dashboard (`config/dashboards/lovelace.yaml`):

- **New badge** on the home view: `sensor.quick_timer_monitor` with a timer icon, showing the active-timer count. Tapping it navigates to `/lovelace/timers`.
- **New hidden subview** (`extra_views`, path `timers`, `subview: true` so it stays out of the tab bar) containing:
  - `custom:quick-timer-overview-card` — lists all active timers
  - `custom:quick-timer-card` in full mode — for setting new timers (30 min default)

## Why

Quick access to timers from the dashboard without cluttering the home view. The badge is the closest chip-equivalent: mushroom-strategy's badge row only accepts badge configs, not full cards, so the overview card itself can't be embedded there — but the monitor sensor's state (active-timer count) conveys the same information, and the tap-through lands on the full cards. This avoids any popup dependency (browser_mod / bubble-card).

## Reviewer notes

- **Prerequisite:** the quick_timer HACS integration must be installed on the HAOS box before promoting this. Until then, the badge and subview render error cards. (HACS state is Tier 3, not yet under GitOps.)
- The `quick-timer-card` ships without a `targets:` list, relying on the card's runtime entity/service discovery. If it turns out to require pre-configured targets in YAML mode, add them per the README, e.g. `targets: [{entity: light.living, service: light.turn_off, phase: finish}]`.
- Projection key ordering kept alphabetical to match the canonical GitOps format.